### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/script.js
+++ b/script.js
@@ -72,8 +72,17 @@ invoiceNameInput.addEventListener('input', () => {
     analyzeButton.disabled = selectedFiles.length === 0 || !invoiceNameInput.value.trim();
 });
 
+function escapeHtml(unsafe) {
+    return unsafe
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#039;");
+}
+
 function updateFileList() {
-    fileList.innerHTML = selectedFiles.map(file => `<p>${file.name}</p>`).join('');
+    fileList.innerHTML = selectedFiles.map(file => `<p>${escapeHtml(file.name)}</p>`).join('');
 }
 
 analyzeButton.addEventListener('click', analyzeInvoices);


### PR DESCRIPTION
Potential fix for [https://github.com/Nec0ti/Fatrocu/security/code-scanning/1](https://github.com/Nec0ti/Fatrocu/security/code-scanning/1)

To fix the problem, we need to ensure that the file names are properly escaped before being inserted into the HTML. This can be achieved by using a function that escapes HTML special characters, preventing any embedded scripts from being executed.

- We will create a function `escapeHtml` that replaces special HTML characters with their corresponding HTML entities.
- We will use this function to sanitize the file names before inserting them into the HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
