### PR TITLE
Potential fix for code scanning alert no. 4: Information exposure through an exception

### DIFF
--- a/backend/fatrocu_app/routes.py
+++ b/backend/fatrocu_app/routes.py
@@ -55,11 +55,11 @@ def upload_file():
 
         except Exception as e:
             # Dosya kaydetme veya process_invoice çağrısı sırasında genel hata
-            print(f"Dosya yükleme/işleme sırasında genel hata: {e}")
+            print(f"Dosya yükleme/işleme sırasında genel hata: {e}")  # Log the detailed error
             # Hata durumunu da JSON olarak kaydetmeye çalışalım
             error_data = {
                  "status": "error", "filename": filename, "extracted_data": None,
-                 "error": f"Yükleme/İşleme sırasında beklenmedik sunucu hatası: {str(e)}"
+                 "error": "Yükleme/İşleme sırasında beklenmedik bir sunucu hatası oluştu."
             }
             save_result(filename, error_data) # Fonksiyon None dönebilir ama denemekte fayda var
             return jsonify(error_data), 500


### PR DESCRIPTION
Potential fix for [https://github.com/Nec0ti/Fatrocu/security/code-scanning/4](https://github.com/Nec0ti/Fatrocu/security/code-scanning/4)

To fix the issue, we will modify the code to ensure that stack trace information is not exposed to the user. Instead, we will log the detailed error information on the server and return a generic error message to the user. Specifically:
1. Replace the inclusion of `str(e)` in the `error_data` dictionary with a generic error message.
2. Log the detailed exception information (e.g., using `print` or a proper logging library) for internal debugging purposes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
